### PR TITLE
Various Fixes

### DIFF
--- a/build_fc_files_w1.py
+++ b/build_fc_files_w1.py
@@ -225,14 +225,16 @@ def build_fc_files_w1(stackupfile, metallist, condlist, widths, outfile, toleran
                 if 'g1_' in line:
                     g1line = line.split()
                     g0 = float(g1line[1])
+
         if proc.stderr:
             print('Error message output from FasterCap:')
             for line in proc.stderr.splitlines():
                 print(line)
-            if proc.returncode != 0:
-                print('ERROR:  FasterCap exited with status ' + str(proc.returncode))
 
-        elif done:
+        if proc.returncode != 0:
+            print('ERROR:  FasterCap exited with status ' + str(proc.returncode))
+
+        if done:
             csub = g0
             ssub = "{:.5g}".format(csub)
             print('Result:  Csub=' + ssub)

--- a/build_fc_files_w1n.py
+++ b/build_fc_files_w1n.py
@@ -234,14 +234,16 @@ def build_fc_files_w1n(stackupfile, metallist, condlist, widths, outfile, tolera
                     g2line = line.split()
                     g10 = float(g2line[1])
                     g11 = float(g2line[2])
+
         if proc.stderr:
             print('Error message output from FasterCap:')
             for line in proc.stderr.splitlines():
                 print(line)
-            if proc.returncode != 0:
-                print('ERROR:  FasterCap exited with status ' + str(proc.returncode))
 
-        elif done:
+        if proc.returncode != 0:
+            print('ERROR:  FasterCap exited with status ' + str(proc.returncode))
+
+        if done:
             # Note:  Where g01 != g10, use the average value.
             # ccoup = -(g01 + g10) / 2.0
             ccoup = -g10

--- a/build_fc_files_w1sh.py
+++ b/build_fc_files_w1sh.py
@@ -233,14 +233,16 @@ def build_fc_files_w1sh(stackupfile, metallist, condlist, subname, widths, seps,
                     g2line = line.split()
                     g10 = float(g2line[1])
                     g11 = float(g2line[2])
+
         if proc.stderr:
             print('Error message output from FasterCap:')
             for line in proc.stderr.splitlines():
                 print(line)
-            if proc.returncode != 0:
-                print('ERROR:  FasterCap exited with status ' + str(proc.returncode))
 
-        elif done:
+        if proc.returncode != 0:
+            print('ERROR:  FasterCap exited with status ' + str(proc.returncode))
+
+        if done:
             msub = g00 + g01
             csub = g10 + g11
             # ccoup = -(g01 + g10) / 2

--- a/build_fc_files_w2.py
+++ b/build_fc_files_w2.py
@@ -234,14 +234,16 @@ def build_fc_files_w2(stackupfile, metallist, condlist, widths, seps, outfile, t
                     g2line = line.split()
                     g10 = float(g2line[1])
                     g11 = float(g2line[2])
+
         if proc.stderr:
             print('Error message output from FasterCap:')
             for line in proc.stderr.splitlines():
                 print(line)
-            if proc.returncode != 0:
-                print('ERROR:  FasterCap exited with status ' + str(proc.returncode))
 
-        elif done:
+        if proc.returncode != 0:
+            print('ERROR:  FasterCap exited with status ' + str(proc.returncode))
+
+        if done:
             cdiag = (g00 + g11) / 2
             # ccoup = -(g01 + g10) / 2
             ccoup = -g10

--- a/build_fc_files_w2o.py
+++ b/build_fc_files_w2o.py
@@ -240,14 +240,16 @@ def build_fc_files_w2o(stackupfile, metal1list, metal2list, widths1, widths2, se
                     g2line = line.split()
                     g10 = float(g2line[1])
                     g11 = float(g2line[2])
+
         if proc.stderr:
             print('Error message output from FasterCap:')
             for line in proc.stderr.splitlines():
                 print(line)
-            if proc.returncode != 0:
-                print('ERROR:  FasterCap exited with status ' + str(proc.returncode))
 
-        elif done:
+        if proc.returncode != 0:
+            print('ERROR:  FasterCap exited with status ' + str(proc.returncode))
+
+        if done:
             m1sub = g00 + g01
             m2sub = g10 + g11
             # ccoup = -(g01 + g10) / 2

--- a/build_mag_files_w1.py
+++ b/build_mag_files_w1.py
@@ -230,6 +230,22 @@ def build_mag_files_w1(stackupfile, startupscript, metallist, condlist, widths, 
             # Just ignore this result
             pass
         else:
+
+            if proc.stdout:
+                if verbose > 1:
+                    print('Diagnostic output from Magic:')
+                for line in proc.stdout.splitlines():
+                    if verbose > 1:
+                        print(line)
+
+            if proc.stderr:
+                print('Error message output from Magic:')
+                for line in proc.stderr.splitlines():
+                    print(line)
+
+            if proc.returncode != 0:
+                print('ERROR:  Magic exited with status ' + str(proc.returncode))
+
             # Remove the .ext file
             os.remove(process + '/magic_files/w1/test.ext')
             # Read output SPICE file

--- a/build_mag_files_w1sh.py
+++ b/build_mag_files_w1sh.py
@@ -240,6 +240,22 @@ def build_mag_files_w1sh(stackupfile, startupscript, metallist, condlist, subnam
             # Just ignore this result
             pass
         else:
+
+            if proc.stdout:
+                if verbose > 1:
+                    print('Diagnostic output from Magic:')
+                for line in proc.stdout.splitlines():
+                    if verbose > 1:
+                        print(line)
+
+            if proc.stderr:
+                print('Error message output from Magic:')
+                for line in proc.stderr.splitlines():
+                    print(line)
+
+            if proc.returncode != 0:
+                print('ERROR:  Magic exited with status ' + str(proc.returncode))
+
             # Remove the .ext file
             os.remove(process + '/magic_files/w1sh/test.ext')
             # When outside of the halo, values will be missing, so assumed zero

--- a/build_mag_files_w2.py
+++ b/build_mag_files_w2.py
@@ -237,6 +237,22 @@ def build_mag_files_w2(stackupfile, startupscript, metallist, condlist, widths, 
             # Just ignore this result
             pass
         else:
+
+            if proc.stdout:
+                if verbose > 1:
+                    print('Diagnostic output from Magic:')
+                for line in proc.stdout.splitlines():
+                    if verbose > 1:
+                        print(line)
+
+            if proc.stderr:
+                print('Error message output from Magic:')
+                for line in proc.stderr.splitlines():
+                    print(line)
+
+            if proc.returncode != 0:
+                print('ERROR:  Magic exited with status ' + str(proc.returncode))
+
             # Remove the .ext file
             os.remove(process + '/magic_files/w2/test.ext')
             # When outside of the halo, values will be missing, so assumed zero

--- a/sky130A/metal_stack_sky130A.py
+++ b/sky130A/metal_stack_sky130A.py
@@ -69,7 +69,7 @@ layers['m4']     = ['m', 4.0211, 0.845, 'nild5', 'nild6']
 layers['nild6']  = ['k', 4.0, 'nild5']
 layers['m5']     = ['m', 5.3711, 1.26, 'nild6', 'topox']
 layers['topox']  = ['s', 3.9, 0.09, 0.07, 'm5'] 
-layers['topnit'] = ['c', 7.5, 0.54, 0.4223, 0.3777, 'topox']
+layers['topnit'] = ['c', 7.5, 0.54, 0.3777, 0.4223, 'topox']
 layers['air']    = ['k', 3.0, 'topnit']
 
 #


### PR DESCRIPTION
This PR fixes a few things:

- Convert README to Markdown
  - Add links to "Requirements" section
- Always parse the result from FasterCap
  - Previously the result was only used when `stderr` was empty. But depending on the version of wxWidgets FasterCap would print harmless "Assert failure" messages.
- Fix swapped values for topnit
  - Fixes #3 
- Get pdk installation from `$PDK_ROOT` if set
- Magic: Print stdout on verbose, always print stderr