### PR TITLE
Metal stackup file for sg13g2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@
 *.eps
 *.spice
 *.ext
+*.tech
+*.magicrc
 __pycache__
 archive

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ variable `FASTERCAP_EXEC` to the full path of FasterCap.
 variable `MAGIC_EXEC` to the full path of magic.
 
 > [!NOTE]  
-> If the PDK is not installed in the default `/usr/local/share/` or commonly
-used `/usr/share/` directories, then pass the location of the PDK `.magicrc`
+> If `PDK_ROOT` is not set and the PDK is not installed in the default `/usr/local/share/` or commonly
+used `/usr/share/` or `~/.volare` directories, then pass the location of the PDK `.magicrc`
 startup file as the 2nd argument to `compute_coefficients.py` (see the
 open_pdks installation instructions for more information).
 
@@ -257,9 +257,13 @@ widths and spacings to simulate.
 
 	magiclayers['<layer_name>'] = '<paint_type>'
 
-This variable is used to map names used in Capiche to layer names
-used in magic.
+This variable is used to map names used in Capiche to layer names used in magic.
 
+> [!NOTE]  
+> Capiche skips the simulation if `poly` is in the name of the metal (conductor) layer and `diff` is in the name of the diffusion layer, since poly to diff is a transistor gate and not parasitic.
+> In the future it may make sense to add an option to the input file whether a layer is `poly` or `diff`.
+
+FasterCap isn't in the standard execution path, set the environment variable `FASTERCAP_EXEC` to the full path of FasterCap.
 
 ## Lower level routines:
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
     for metal wires that have sidewall dielectric.  Corrected the
     handling of TOPOX over metal 5 in sky130A, which was previously
     capturing the sidewall but not the dielectric above the metal.
-
   - **January 29, 2023:**  Additional errors in FasterCap intput
     files based on feedback from the FasterCap developer.
+  - **December 2024:**  Automatically generate tech file for magic - Leo
 
 
 ## Requirements:
@@ -258,6 +258,22 @@ widths and spacings to simulate.
 	magiclayers['<layer_name>'] = '<paint_type>'
 
 This variable is used to map names used in Capiche to layer names used in magic.
+
+    magicextractstyle = `<extract_style>`
+
+This variable is used to set the extract style in magic.
+
+	magicplanes['<layer_name>'] = '<TODO>'
+
+TODO
+
+	magicaliases['<layer_name>'] = '<TODO>'
+
+TODO
+
+	magicstyles['<layer_name>'] = '<TODO>'
+
+TODO
 
 > [!NOTE]  
 > Capiche skips the simulation if `poly` is in the name of the metal (conductor) layer and `diff` is in the name of the diffusion layer, since poly to diff is a transistor gate and not parasitic.

--- a/capiche.py
+++ b/capiche.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+# Entry point for capiche
+
+import argparse
+
+from compute_coefficients import compute_coefficients
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(
+        prog='capiche',
+        description='A system for analyzing foundry metal stackups using FasterCap',
+        epilog='https://github.com/RTimothyEdwards/capiche/')
+    
+    # Add arguments
+    parser.add_argument('stack_def_file', type=str, help='Stack definition file')
+    parser.add_argument('magic_startup_file', type=str, nargs='?', help="Instead of using the auto-generated magic startup file, use the provided one")
+    
+    parser.add_argument('-noshield', action='store_false', help='Do not run fringe shield simulations')
+    parser.add_argument('-nopartial', action='store_false', help='Do not run partial fringe simulations')
+    parser.add_argument('-nosidewall', action='store_false', help='Do not run sidewall simulations')
+    
+    parser.add_argument('-verbose', type=int, default=0, help='Diagnostic level')
+    
+    # Parss the arguments
+    args = parser.parse_args()
+
+    # Compute the coefficients
+    compute_coefficients(args.stack_def_file, args.magic_startup_file, not args.noshield, not args.nopartial, not args.nosidewall, args.verbose)
+
+    # Exit
+    sys.exit(0)

--- a/compute_coefficients.py
+++ b/compute_coefficients.py
@@ -341,7 +341,7 @@ def compute_fringe(process, metals, substrates, areacap, size):
         width = minwidth * size
 
         for subs in substrates:
-            if 'diff' in subs and metal == 'poly':
+            if 'diff' in subs and 'poly' in metal:
                 continue
             with open(process + '/analysis/fringe/' + metal + '_' + subs + '.txt', 'r') as ifile:
                 lines = ifile.read().splitlines()
@@ -441,7 +441,7 @@ def compute_fringeshield(process, metals, limits, substrates, areacap, fringe10)
         for conductor in conductors:
 
             # Ignore poly over diff, which is not considered a parasitic
-            if 'diff' in conductor and metal == 'poly':
+            if 'diff' in conductor and 'poly' in metal:
                 continue
 
             xdata = []
@@ -564,7 +564,7 @@ def validate_fringe(process, stackupfile, startupfile, metals, substrates, limit
         wstop = '{:.2f}'.format(11 * minwidth)
         wstep = '{:.2f}'.format(9 * minwidth)
         for subs in substrates:
-            if 'diff' in subs and metal == 'poly':
+            if 'diff' in subs and 'poly' in metal:
                 continue
             if not os.path.isfile(process + '/validate/fringe/' + metal + '_' + subs + '.txt'):
                 if verbose > 0:
@@ -732,7 +732,7 @@ def print_coefficients(metals, substrates, areacap, fringe, sidewall, fringeshie
 
         print('  areacap (aF/um^2) to:')
         for subs in substrates:
-            if 'diff' in subs and metal == 'poly':
+            if 'diff' in subs and 'poly' in metal:
                 continue
             print('    ' + subs + ' = {:.3f}'.format(areacap[metal + '+' + subs]))
         for cond in metals:
@@ -744,7 +744,7 @@ def print_coefficients(metals, substrates, areacap, fringe, sidewall, fringeshie
         print('')
         print('  fringecap (aF/um) to:')
         for subs in substrates:
-            if 'diff' in subs and metal == 'poly':
+            if 'diff' in subs and 'poly' in metal:
                 continue
             print('    ' + subs + ' = {:.3f}'.format(fringe[metal + '+' + subs]))
         for cond in metals:
@@ -762,7 +762,7 @@ def print_coefficients(metals, substrates, areacap, fringe, sidewall, fringeshie
             print('')
             print('  fringe shielding to:')
             for subs in substrates:
-                if 'diff' in subs and metal == 'poly':
+                if 'diff' in subs and 'poly' in metal:
                     continue
                 print('    ' + subs + ':')
                 print('    multiplier = {:.3f}'.format(fringeshield[metal + '+' + subs][0]))
@@ -798,7 +798,7 @@ def save_coefficients(metals, substrates, areacap, fringe, sidewall, fringeshiel
     with open(outfile, 'w') as ofile:
         for metal in metals:
             for subs in substrates:
-                if 'diff' in subs and metal == 'poly':
+                if 'diff' in subs and 'poly' in metal:
                     continue
                 print('areacap ' + metal + ' ' + subs + ' {:.3f}'.format(areacap[metal + '+' + subs]), file=ofile)
             for cond in metals:
@@ -808,7 +808,7 @@ def save_coefficients(metals, substrates, areacap, fringe, sidewall, fringeshiel
                     except:
                         print('areacap ' + metal + ' ' + cond + ' {:.3f}'.format(areacap[cond + '+' + metal]), file=ofile)
             for subs in substrates:
-                if 'diff' in subs and metal == 'poly':
+                if 'diff' in subs and 'poly' in metal:
                     continue
                 print('fringecap ' + metal + ' ' + subs + ' {:.3f}'.format(fringe[metal + '+' + subs]), file=ofile)
             for cond in metals:
@@ -821,7 +821,7 @@ def save_coefficients(metals, substrates, areacap, fringe, sidewall, fringeshiel
 
             if fringeshield:
                 for subs in substrates:
-                    if 'diff' in subs and metal == 'poly':
+                    if 'diff' in subs and 'poly' in metal:
                         continue
                     print('fringeshield ' + metal + ' ' + subs + ' ' + '{:.3f}'.format(fringeshield[metal + '+' + subs][0]) + ' ' + '{:.3f}'.format(fringeshield[metal + '+' + subs][1]), file=ofile)
                 for cond in metals:
@@ -856,7 +856,7 @@ def save_coefficients(metals, substrates, areacap, fringe, sidewall, fringeshiel
         with open('test.dat', 'w') as ofile:
             for metal in metals:
                 for subs in substrates:
-                    if 'diff' in subs and metal == 'poly':
+                    if 'diff' in subs and 'poly' in metal:
                         continue
                     if metal + '+' + subs not in fringepartial:
                         fringepartial[metal + '+' + subs] = [0, 0]
@@ -1361,6 +1361,7 @@ if __name__ == '__main__':
             # Check whether startupfile exists
             startupfile = os.path.join(pdk_root, process, 'libs.tech', 'magic', f'{process}.magicrc')
             if not os.path.isfile(startupfile):
+                print(f'Could not find startupfile: {startupfile}')
                 startupfile = None
 
         else:

--- a/create_mag_techfile.py
+++ b/create_mag_techfile.py
@@ -1,0 +1,248 @@
+# TODO
+
+import os
+import sys
+import numpy
+import subprocess
+
+def create_mag_techfile(stackupfile, metals, substrates, areacap, fringe, sidewall, fringeshield, fringepartial, verbose=0):
+    """
+    """
+
+    #--------------------------------------------------------------
+    # Obtain the metal stack.  The metal stack file is in the
+    # format of executable python, so use exec().
+    #--------------------------------------------------------------
+
+    try:
+        locals = {}
+        exec(open(stackupfile, 'r').read(), None, locals)
+    except:
+        print('Error:  No metal stack file ' + stackupfile + '!')
+        return 1
+
+    try:
+        process = locals['process']
+    except:
+        print('Warning:  Metal stack does not define process!')
+        process = 'unknown'
+
+    try:
+        layers = locals['layers']
+    except:
+        print('Error:  Metal stack does not define layers!')
+        return 1
+
+    try:
+        limits = locals['limits']
+    except:
+        print('Error:  Metal stack does not define limits!')
+        return 1
+
+    try:
+        magiclayers = locals['magiclayers']
+    except:
+        print('Error:  Metal stack does not define magiclayers!')
+        return 1
+
+    try:
+        magicextractstyle = locals['magicextractstyle']
+    except:
+        # Use default
+        magicextractstyle = None
+
+    try:
+        magicplanes = locals['magicplanes']
+    except:
+        print('Error:  Metal stack does not define magicplanes!')
+        return 1
+
+    try:
+        magicaliases = locals['magicaliases']
+    except:
+        print('Error:  Metal stack does not define magicaliases!')
+        return 1
+
+    try:
+        magicstyles = locals['magicstyles']
+    except:
+        print('Error:  Metal stack does not define magicstyles!')
+        return 1
+
+    # Get the unique list of planes, but keep the order
+    seen = set()
+    unique_planes = [plane for plane in magicplanes.values() if not (plane in seen or seen.add(plane))]
+
+    # Get the name for the substrate
+    # This is the first layer in the stackup
+    substrate_name = substrates[0]
+
+    print(metals)
+    print(substrates)
+    print(areacap)
+    print(fringe)
+    print(sidewall)
+    print(fringeshield)
+    print(fringepartial)
+
+    """
+    TODO: how to handle ndiff,mvndiff->allactivenonfet?
+    merge layers with same alias and only use first entry?
+    but ndiff,mvndiff have different results...
+    
+    TODO: deep nwell
+    
+    """
+
+    ext_data = ''
+    for metal in metals:
+        
+        layer = magiclayers[metal]
+        plane = magicplanes[metal]
+        alias = magicaliases[metal]
+        
+        layer_or_alias = alias if alias != None else layer
+        
+        print(layer)
+        print(plane)
+        print(alias)
+        
+        ext_data += f"""# {metal}
+ defaultsidewall    {layer_or_alias} {plane} {sidewall[metal][0]:.3f} {sidewall[metal][1]:.3f}
+ defaultareacap     {layer_or_alias} {plane} {areacap[metal+'+'+substrate_name]:.3f}
+ defaultperimeter   {layer_or_alias} {plane} {fringe[metal+'+'+substrate_name]:.3f}\n\n"""
+
+        for substrate in substrates:
+            # Ignore transistor gates
+            if 'diff' in substrate and 'poly' in metal:
+                continue
+            print(substrate)
+            
+            subs_layer = magiclayers[substrate]
+            subs_plane = magicplanes[substrate]
+            subs_alias = magicaliases[substrate]
+            
+            subs_layer_or_alias = subs_alias if subs_alias != None else subs_layer
+            
+            print(subs_layer)
+            print(subs_plane)
+            print(subs_alias)
+
+            ext_data += f"""# {metal}->{substrate}
+ defaultoverlap     {layer_or_alias} {plane} {subs_layer_or_alias} {subs_plane}  {areacap[metal+'+'+substrate]:.3f}
+ defaultsideoverlap {layer_or_alias} {plane} {subs_layer_or_alias} {subs_plane}  {fringe[metal+'+'+substrate]:.3f}\n\n"""
+
+        for other_metal in metals:
+            # Ignore everything above and myself
+            if metals.index(other_metal) >= metals.index(metal):
+                continue
+        
+            print(substrate)
+            
+            met_layer = magiclayers[other_metal]
+            met_plane = magicplanes[other_metal]
+            met_alias = magicaliases[other_metal]
+            
+            met_layer_or_alias = met_alias if met_alias != None else met_layer
+            
+            print(met_layer)
+            print(met_plane)
+            print(met_alias)
+
+            ext_data += f"""# {metal}->{other_metal}
+ defaultoverlap     {layer_or_alias} {plane} {met_layer_or_alias} {met_plane} {areacap[metal+'+'+other_metal]:.3f}
+ defaultsideoverlap {layer_or_alias} {plane} {met_layer_or_alias} {met_plane} {fringe[metal+'+'+other_metal]:.3f}
+ defaultsideoverlap {met_layer_or_alias} {met_plane} {layer_or_alias} {plane} {fringe[other_metal+'+'+metal]:.3f}\n\n"""
+
+
+
+    print(ext_data)
+
+    # TODO generate magic tech file
+    if True:
+        with open(os.path.join(process, 'magic', f'{process}.tech'), 'w') as magictech_file:
+            magictech_file.write(f"""tech
+  format 35
+  {process}
+end
+
+version
+  version 0.0
+  description "Dummy technology file generated by capiche"
+end
+
+planes
+{'\n'.join(['  ' + plane for plane in unique_planes])}
+end
+
+types
+{'\n'.join(['  ' + plane + ' ' + magiclayers[layer] for layer, plane in magicplanes.items()])}
+end
+
+contact
+end
+
+aliases
+{'\n'.join(['  ' + alias + ' ' + magiclayers[layer] for layer, alias in magicaliases.items() if alias != None])}
+end
+
+styles
+ styletype mos
+{'\n'.join(['  ' + magiclayers[layer] + ' ' + style for layer, style in magicstyles.items()])}
+end
+
+compose
+end
+
+connect
+end
+
+cifoutput
+ style gdsii
+ scalefactor 10  nanometers
+ gridlimit 5
+end
+
+cifinput
+end
+
+# mzrouter
+# end
+
+drc
+end
+
+extract
+ style ngspice variants ()
+ cscale 1
+
+ variants *
+ lambda 1.0
+
+ units	microns
+ step   7
+ sidehalo 8
+ fringeshieldhalo 8
+
+{'\n'.join([' planeorder ' + plane + ' ' + str(i) for i, plane in enumerate(unique_planes)])}
+
+variants ()
+# Nominal capacitances
+
+# Note: This section was auto-generated by capiche
+
+{ext_data}
+end
+
+# wiring
+# end
+
+# router
+# end
+
+# plowing
+# end
+
+# plot
+# end 
+""")

--- a/ihp-sg13g2/metal_stack_ihp-sg13g2.py
+++ b/ihp-sg13g2/metal_stack_ihp-sg13g2.py
@@ -1,10 +1,10 @@
 #
-# metal_stack_sg13g2.py ---
+# metal_stack_ihp-sg13g2.py ---
 #
 #	Input file for build_fc_files.py.
-#	This describes the metal stack for the sg13g2 process
+#	This describes the metal stack for the ihp-sg13g2 process
 #
-process = 'sg13g2'	# Process name
+process = 'ihp-sg13g2'	# Process name
 feature_size = 0.13	# process minimum gate length (for general scaling)
 
 # Well/substrate is assumed to define Y = 0.

--- a/ihp-sg13g2/metal_stack_ihp-sg13g2.py
+++ b/ihp-sg13g2/metal_stack_ihp-sg13g2.py
@@ -125,3 +125,48 @@ magiclayers['metal4'] = 'm4'
 magiclayers['metal5'] = 'm5'
 magiclayers['topmetal1'] = 'm6'
 magiclayers['topmetal2'] = 'm7'
+
+# Optional - automatic tech file generation for magic
+
+magicplanes = {}
+magicplanes['subs'] = 'well'
+magicplanes['nwell'] = 'well'
+magicplanes['diff'] = 'active'
+magicplanes['hvdiff'] = 'active'
+magicplanes['gatpoly'] = 'active'
+magicplanes['metal1'] = 'metal1'
+magicplanes['metal2'] = 'metal2'
+magicplanes['metal3'] = 'metal3'
+magicplanes['metal4'] = 'metal4'
+magicplanes['metal5'] = 'metal5'
+magicplanes['topmetal1'] = 'metal6'
+magicplanes['topmetal2'] = 'metal7'
+
+magicaliases = {}
+magicaliases['subs'] = None
+magicaliases['nwell'] = None
+magicaliases['diff'] = 'alldifflvnonfet'
+magicaliases['hvdiff'] = 'alldiffhvnonfet'
+magicaliases['gatpoly'] = 'allpoly'
+magicaliases['metal1'] = 'allm1'
+magicaliases['metal2'] = 'allm2'
+magicaliases['metal3'] = 'allm3'
+magicaliases['metal4'] = 'allm4'
+magicaliases['metal5'] = 'allm5'
+magicaliases['topmetal1'] = 'allm6'
+magicaliases['topmetal2'] = 'allm7'
+
+magicstyles = {}
+magicstyles['subs'] = 'pwell'
+magicstyles['nwell'] = 'nwell'
+magicstyles['diff'] = 'ndiffusion'
+magicstyles['hvdiff'] = 'ndiffusion'
+magicstyles['gatpoly'] = 'polysilicon'
+magicstyles['metal1'] = 'metal1'
+magicstyles['metal2'] = 'metal2'
+magicstyles['metal3'] = 'metal3'
+magicstyles['metal4'] = 'metal4'
+magicstyles['metal5'] = 'metal5'
+magicstyles['topmetal1'] = 'metal6'
+magicstyles['topmetal2'] = 'metal7'
+

--- a/sg13g2/metal_stack_sg13g2.py
+++ b/sg13g2/metal_stack_sg13g2.py
@@ -1,0 +1,141 @@
+#
+# metal_stack_sg13g2.py ---
+#
+#	Input file for build_fc_files.py.
+#	This describes the metal stack for the sg13g2 process
+#
+process = 'sg13g2'	# Process name
+feature_size = 0.13	# process minimum gate length (for general scaling)
+
+# Well/substrate is assumed to define Y = 0.
+# All dimension values are in microns
+#
+# Layer types:
+# 'd':  diffusion.  Defines the ground plane (conducting layer), which may
+#	be the substrate, well, or diffusion.  Has two arguments;  the
+#	first argument is a height value of the top of the diffusion/well/
+#	substrate.  The second is the name of the dielectric type above
+#	the ground plane.  Several diffusion/well/substrate types may be
+#	declared, but only one can be used in any given output file.
+# 'k':	dielectric.  Has two arguments, which are dielectric constant and
+#	the name of the dielectric layer underneath it.  Thickness varies
+#	according to presence or absence of the metal or a conforming
+#	dielectric.
+# 'f':  field oxide dielectric.  Has one argument, which is the dielectric
+#	constant.  The associated layer is always either well or diffusion,
+#	and separate tables will be generated for both cases.
+# 'b':  boundary dielectric.  Has three arguments, which are the height
+#	above the substrate, dielectric constant, and the name of the
+#	dielectric layer beneath it.  Like 'k', but used when a dielectric
+#	layer is added that has no relationship to a metal underneath.
+# 'c':	conforming dielectric.  Has five arguments, which are dielectric
+#	constant, thickness above the associated layer, sidewall width,
+#	thickness when not over the associated layer, and an associated
+#	metal or dielectric layer.  Thickness is constant, but height will
+#	vary according to presence or absence of a coincident metal layer.
+#	The dielectric underneath is assumed to be the same as the dielectric
+#	underneath the associated layer.
+# 's':	sidewall dielectric.  Has four arguments, which are dielectric
+#	constant, thickness, sidewall width, and associated metal layer.
+#	Thickness is constant, but height will vary according to presence
+#	or absence of a coincident metal layer.  The dielectric underneath
+#	is assumed to be the same as the dielectric underneath the associated
+#	metal layer.  Sidewall dielectrics are just conforming dielectrics
+#	with no thickness except above the associated metal layer.
+# 'm':  Metal (conductor) layer.  Has four arguments, which are the layer
+#	height and layer thickness, the dielectric layer underneath, and
+#	the dielectric layer on top (and on the sides, if there is no
+#	associated conformal dielectric).  Includes any conductor such as
+#	poly, local interconnect, etc.
+
+# https://github.com/IHP-GmbH/IHP-Open-PDK/blob/main/ihp-sg13g2/libs.doc/doc/SG13G2_os_process_spec.pdf
+
+layers = {}
+layers['subs']	 = ['d', 0.0000, 'fox']
+layers['nwell']  = ['d', 0.0000, 'fox']
+layers['diff']   = ['d', 0.3120, 'fox'] # TODO top height
+layers['mvdiff'] = ['d', 0.3048, 'fox'] # TODO top height
+layers['fox']    = ['f', 3.95]
+
+layers['gatpoly'] = ['m', 0.4, 0.16, 'fox', 'nit']
+layers['nit']     = ['c', 6.5, 0.05, 0.05, 0.05, 'gatpoly']
+layers['ild']     = ['k', 4.1, 'nit']
+
+layers['metal1'] = ['m', 0.4 + 0.64, 0.42, 'ild', 'imd1']
+layers['imd1']   = ['k', 4.1, 'ild']
+
+layers['metal2'] = ['m', 0.4 + 0.64 + (0.42 + 0.54), 0.49, 'imd1', 'imd2']
+layers['imd2']   = ['k', 4.1, 'imd1']
+
+layers['metal3'] = ['m', 0.4 + 0.64 + (0.42 + 0.54) + (0.49 + 0.54), 0.49, 'imd2', 'imd3']
+layers['imd3']   = ['k', 4.1, 'imd2']
+
+layers['metal4'] = ['m', 0.4 + 0.64 + (0.42 + 0.54) + (0.49 + 0.54) * 2, 0.49, 'imd3', 'imd4']
+layers['imd4']   = ['k', 4.1, 'imd3']
+
+layers['metal5'] = ['m', 0.4 + 0.64 + (0.42 + 0.54) + (0.49 + 0.54) * 3, 0.49, 'imd4', 'imd5']
+layers['imd5']   = ['k', 4.1, 'imd4']
+
+layers['topmetal1'] = ['m', 0.4 + 0.64 + (0.42 + 0.54) + (0.49 + 0.54) * 3 + (0.49 + 0.85), 2.0, 'imd5', 'imd6']
+layers['imd6']      = ['k', 4.1, 'imd5']
+
+layers['topmetal2'] = ['m', 0.4 + 0.64 + (0.42 + 0.54) + (0.49 + 0.54) * 3 + (0.49 + 0.85) + (2.0 + 2.8), 3.0, 'imd6', 'pass']
+layers['imd7']      = ['c', 4.1, 1.5, 0.3, 1.5, 'imd6'] # TODO dielectric constant, sidewall thickness, thickness when not over the associated layer
+layers['pass']      = ['c', 6.6, 0.4, 0.3, 0.4, 'imd7'] # TODO sidewall thickness, thickness when not over the associated layer
+layers['air']       = ['k', 3.0, 'pass']
+
+#
+# Define metal width and spacing minimum limits.
+# There must be one entry for each layer type 'm' defined above.
+# 1st value is minimum width, 2nd value is minimum spacing
+
+# https://github.com/IHP-GmbH/IHP-Open-PDK/blob/main/ihp-sg13g2/libs.doc/doc/SG13G2_os_layout_rules.pdf
+
+limits = {}
+# 5.8 GatPoly
+limits['gatpoly'] = [0.13, 0.18]
+# 5.16 Metal1
+limits['metal1'] = [0.16, 0.18]
+# 5.17 Metal2-5
+limits['metal2'] = [0.20, 0.21]
+limits['metal3'] = [0.20, 0.21]
+limits['metal4'] = [0.20, 0.21]
+limits['metal5'] = [0.20, 0.21]
+# 5.22 TopMetal1
+limits['topmetal1'] = [1.64, 1.64]
+# 5.25 TopMetal2
+limits['topmetal2'] = [2.0, 2.0]
+
+#
+# Define the (known and agreed-upon) parallel plate capacitance
+# 4 values are cap to substrate, nwell, lv-diffusion, and mv-diffusion
+# (NOTE: This section is optional.  Plate capacitances are computed
+# directly)
+
+# TODO Where can I get these values?
+platecap = {}
+#platecap['poly'] = [110.68, 110.68,  4427,  2330 ]
+#platecap['m1']   = [ 29.30,  29.30,  39.2,  39.2 ]
+#platecap['m2']   = [ 12.37,  12.37,  17.3,  17.3 ]
+#platecap['m3']   = [ 10.09,  10.09,  11.1,  11.1 ]
+#platecap['m4']   = [  7.60,   7.60,  8.14,   8.14]
+#platecap['m5']   = [  5.80,   5.80,  6.10,   6.10]
+
+#
+# Define the relationship between metal layers in this file
+# and layers in magic (for use with magic extraction)
+
+# TODO check layers
+magiclayers = {}
+magiclayers['subs'] = 'pwell'
+magiclayers['nwell'] = 'nwell'
+magiclayers['diff'] = 'ndiff'
+magiclayers['mvdiff'] = 'mvndiff'
+magiclayers['gatpoly'] = 'poly'
+magiclayers['metal1'] = 'm1'
+magiclayers['metal2'] = 'm2'
+magiclayers['metal3'] = 'm3'
+magiclayers['metal4'] = 'm4'
+magiclayers['metal5'] = 'm5'
+magiclayers['topmetal1'] = 'm6'
+magiclayers['topmetal2'] = 'm7'

--- a/sg13g2/metal_stack_sg13g2.py
+++ b/sg13g2/metal_stack_sg13g2.py
@@ -54,7 +54,7 @@ layers = {}
 layers['subs']	 = ['d', 0.0000, 'fox']
 layers['nwell']  = ['d', 0.0000, 'fox']
 layers['diff']   = ['d', 0.3120, 'fox'] # TODO top height
-layers['mvdiff'] = ['d', 0.3048, 'fox'] # TODO top height
+layers['hvdiff'] = ['d', 0.3048, 'fox'] # TODO top height
 layers['fox']    = ['f', 3.95]
 
 layers['gatpoly'] = ['m', 0.4, 0.16, 'fox', 'nit']
@@ -107,30 +107,14 @@ limits['topmetal1'] = [1.64, 1.64]
 limits['topmetal2'] = [2.0, 2.0]
 
 #
-# Define the (known and agreed-upon) parallel plate capacitance
-# 4 values are cap to substrate, nwell, lv-diffusion, and mv-diffusion
-# (NOTE: This section is optional.  Plate capacitances are computed
-# directly)
-
-# TODO Where can I get these values?
-platecap = {}
-#platecap['poly'] = [110.68, 110.68,  4427,  2330 ]
-#platecap['m1']   = [ 29.30,  29.30,  39.2,  39.2 ]
-#platecap['m2']   = [ 12.37,  12.37,  17.3,  17.3 ]
-#platecap['m3']   = [ 10.09,  10.09,  11.1,  11.1 ]
-#platecap['m4']   = [  7.60,   7.60,  8.14,   8.14]
-#platecap['m5']   = [  5.80,   5.80,  6.10,   6.10]
-
-#
 # Define the relationship between metal layers in this file
 # and layers in magic (for use with magic extraction)
 
-# TODO check layers
 magiclayers = {}
 magiclayers['subs'] = 'pwell'
 magiclayers['nwell'] = 'nwell'
 magiclayers['diff'] = 'ndiff'
-magiclayers['mvdiff'] = 'mvndiff'
+magiclayers['hvdiff'] = 'hvndiff'
 magiclayers['gatpoly'] = 'poly'
 magiclayers['metal1'] = 'm1'
 magiclayers['metal2'] = 'm2'

--- a/sg13g2/metal_stack_sg13g2.py
+++ b/sg13g2/metal_stack_sg13g2.py
@@ -54,9 +54,9 @@ layers = {}
 layers['subs']	 = ['d', 0.0000, 'fox']
 layers['nwell']  = ['d', 0.0000, 'fox']
 # LV gate oxide is 2.65nm
-layers['diff']   = ['d', 0.4 - 0.00265, 'fox']
+layers['diff']   = ['d', 0.4 - 0.00245, 'fox']
 # HV gate oxide is 7.5nm
-layers['hvdiff'] = ['d', 0.4 - 0.0075, 'fox']
+layers['hvdiff'] = ['d', 0.4 - 0.0073, 'fox']
 layers['fox']    = ['f', 3.95]
 
 layers['gatpoly'] = ['m', 0.4, 0.16, 'fox', 'nit']

--- a/sg13g2/metal_stack_sg13g2.py
+++ b/sg13g2/metal_stack_sg13g2.py
@@ -53,8 +53,10 @@ feature_size = 0.13	# process minimum gate length (for general scaling)
 layers = {}
 layers['subs']	 = ['d', 0.0000, 'fox']
 layers['nwell']  = ['d', 0.0000, 'fox']
-layers['diff']   = ['d', 0.3120, 'fox'] # TODO top height
-layers['hvdiff'] = ['d', 0.3048, 'fox'] # TODO top height
+# LV gate oxide is 2.65nm
+layers['diff']   = ['d', 0.4 - 0.00265, 'fox']
+# HV gate oxide is 7.5nm
+layers['hvdiff'] = ['d', 0.4 - 0.0075, 'fox']
 layers['fox']    = ['f', 3.95]
 
 layers['gatpoly'] = ['m', 0.4, 0.16, 'fox', 'nit']
@@ -80,8 +82,8 @@ layers['topmetal1'] = ['m', 0.4 + 0.64 + (0.42 + 0.54) + (0.49 + 0.54) * 3 + (0.
 layers['imd6']      = ['k', 4.1, 'imd5']
 
 layers['topmetal2'] = ['m', 0.4 + 0.64 + (0.42 + 0.54) + (0.49 + 0.54) * 3 + (0.49 + 0.85) + (2.0 + 2.8), 3.0, 'imd6', 'pass']
-layers['imd7']      = ['c', 4.1, 1.5, 0.3, 1.5, 'imd6'] # TODO dielectric constant, sidewall thickness, thickness when not over the associated layer
-layers['pass']      = ['c', 6.6, 0.4, 0.3, 0.4, 'imd7'] # TODO sidewall thickness, thickness when not over the associated layer
+layers['imd7']      = ['c', 4.1, 1.5, 0.3, 1.5, 'imd6']
+layers['pass']      = ['c', 6.6, 0.4, 0.3, 0.4, 'imd7']
 layers['air']       = ['k', 3.0, 'pass']
 
 #

--- a/sky130A/metal_stack_sky130A.py
+++ b/sky130A/metal_stack_sky130A.py
@@ -117,3 +117,45 @@ magiclayers['m2'] = 'm2'
 magiclayers['m3'] = 'm3'
 magiclayers['m4'] = 'm4'
 magiclayers['m5'] = 'm5'
+
+# Optional - automatic tech file generation for magic
+
+magicplanes = {}
+magicplanes['subs'] = 'well'
+magicplanes['nwell'] = 'well'
+magicplanes['diff'] = 'active'
+magicplanes['mvdiff'] = 'active'
+magicplanes['poly'] = 'active'
+magicplanes['li'] = 'locali'
+magicplanes['m1'] = 'metal1'
+magicplanes['m2'] = 'metal2'
+magicplanes['m3'] = 'metal3'
+magicplanes['m4'] = 'metal4'
+magicplanes['m5'] = 'metal5'
+
+magicaliases = {}
+magicaliases['subs'] = None
+magicaliases['nwell'] = None
+magicaliases['diff'] = 'alldifflvnonfet'
+magicaliases['mvdiff'] = 'alldiffmvnonfet'
+magicaliases['poly'] = 'allpoly'
+magicaliases['li'] = 'allli'
+magicaliases['m1'] = 'allm1'
+magicaliases['m2'] = 'allm2'
+magicaliases['m3'] = 'allm3'
+magicaliases['m4'] = 'allm4'
+magicaliases['m5'] = 'allm5'
+
+magicstyles = {}
+magicstyles['subs'] = 'pwell'
+magicstyles['nwell'] = 'nwell'
+magicstyles['diff'] = 'ndiffusion'
+magicstyles['mvdiff'] = 'ndiffusion'
+magicstyles['poly'] = 'polysilicon'
+magicstyles['li'] = 'metal1'
+magicstyles['m1'] = 'metal2'
+magicstyles['m2'] = 'metal3'
+magicstyles['m3'] = 'metal4'
+magicstyles['m4'] = 'metal5'
+magicstyles['m5'] = 'metal6'
+


### PR DESCRIPTION
This is the work in progress sg13g2 metal stackup file.

There are still some bits I'm unsure about, especially in the lower and upper layers.

- ~~What is the top height of `diff`/`hvdiff`? In the `gf180mcuD` stackup, there is a note that the position depends on the oxide thickness of the 3.3V and 6.0V devices. So we need to get the oxide thickness of the 1.2V / 3.3V devices for sg13g2? Can this be found in the model files?~~
  Gate oxide thicknesses are listed on page 17 in the `SG13G2_os_process_spec`.

- ~~From what I can see, TopMetal2 has two different conformal dielectrics. The first one is missing its dielectric constant, I have set it to 4.1 for now. The thickness when not over the associated layer is missing for both. The sidewall thickness is given as a total value for both, so I divided it by two for now: 600nm/2=300nm~~
  Assumption was correct.

- ~~Should I omit the values for `platecap`? Where would I take them from? Are the computed values saved under `analysis/areacap/results.txt`? For `gf180mcuD` and `sky130A` they are not exactly the same as the ones in the stackup.~~
  Removed as it is optional.

- ~~What are the correct layer names for some of the layers? For now, I just copied the names from `gf180mcuD` for `imd1-7`.~~
  The names are okay.

Note: The height calculations are written out in full, to make it easer to find any errors. 